### PR TITLE
Export apiClient also as named export

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.transformParamsFunctions = exports.decamelizeOrderingParam = undefined;
+exports.apiClient = exports.transformParamsFunctions = exports.decamelizeOrderingParam = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -48,7 +48,7 @@ transformResponse = [].concat(_toConsumableArray(transformResponse), [_humps2.de
 
 var transformParamsFunctions = exports.transformParamsFunctions = [_humps2.default.decamelizeKeys, _stringifyParams2.default];
 
-var apiClient = _axios2.default.create({
+var apiClient = exports.apiClient = _axios2.default.create({
   transformRequest: transformRequest,
   transformResponse: transformResponse,
   paramsSerializer: paramsSerializer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "api-client",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-client",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Promise based HTTP client for the browser and node.js based on axios",
   "main": "lib/index.js",
   "repository": "github:HealthByRo/api-client",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export const transformParamsFunctions = [
   stringifyParams,
 ];
 
-const apiClient = axios.create({
+export const apiClient = axios.create({
   transformRequest,
   transformResponse,
   paramsSerializer,


### PR DESCRIPTION
Native Node 14 ESM gets confused by this package and `import apiClient from 'api-client';` imports the entire `package.exports` and `apiClient` is at `apiClient.default`. This allows a simple named import.